### PR TITLE
ci: bump actions/upload-artifact to v7 for the Node 24 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
         run: pnpm exec vsce package --target ${{ matrix.vsce-target }} -o rstack-${{ matrix.vsce-target }}.vsix
 
       - name: Upload VSIX Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: rstack-${{ matrix.vsce-target }}
           path: packages/vscode/rstack-${{ matrix.vsce-target }}.vsix


### PR DESCRIPTION
## Summary

Release-workflow run [30985104980](https://github.com/rstackjs/rstack-editor/actions/runs/30985104980) emitted a deprecation warning on every job:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/upload-artifact@ea165f8d` (v4).

This bumps the pin to `actions/upload-artifact@v7.0.1` (`043fb46d`), which targets Node 24 natively.

- v5 was the Node 24 runtime bump; v6 raised the minimum runner to 2.327.1 (GitHub-hosted runners already satisfy it); v7 only added the opt-in `archive: false` direct-upload mode. None of these change the inputs used here (`name`/`path`/`if-no-files-found`).
- All other pinned actions (`checkout` v6.1.0, `setup-node` v6.5.0, `cache` v6.1.0, `pnpm/action-setup` v6.0.9) already target Node 24 — run 30985104980 produced no annotations for them, so `upload-artifact` is the only pin that needed a bump.

## Verification

`release.yml` only runs on `workflow_dispatch`, so this cannot be exercised pre-merge; a `dry_run=true` dispatch after merge confirms the warning is gone.