### PR TITLE
chore(vscode): complete the Marketplace manifest for the first release

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -24,6 +24,7 @@
     "url": "git+https://github.com/rstackjs/rstack-editor.git"
   },
   "license": "MIT",
+  "qna": "https://github.com/rstackjs/rstack-editor/issues",
   "publisher": "rstack",
   "main": "./dist/extension.js",
   "scripts": {
@@ -201,6 +202,7 @@
           "rstack.rstest.testCaseCollectMethod": {
             "order": 3,
             "type": "string",
+            "description": "How test cases are discovered inside a test file: statically from the AST, or by running the file and collecting the registered tests.",
             "default": "ast",
             "enum": [
               "ast",
@@ -455,7 +457,12 @@
     "vscode": "^1.97.0"
   },
   "icon": "icon.png",
+  "preview": true,
   "capabilities": {
+    "virtualWorkspaces": {
+      "supported": false,
+      "description": "Rstack resolves `@rslint/core`, `@rstest/core` and `rstack` from the workspace's node_modules and spawns them as local processes, which needs a real file system."
+    },
     "untrustedWorkspaces": {
       "supported": "limited",
       "description": "Rstack spawns project-local executables (the Rslint language server, the Rstest worker, `rs fmt`) and loads project configuration files. In Restricted Mode only the status bar item is shown; no process is spawned and no project code is loaded."

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -460,8 +460,8 @@
   "preview": true,
   "capabilities": {
     "virtualWorkspaces": {
-      "supported": false,
-      "description": "Rstack resolves `@rslint/core`, `@rstest/core` and `rstack` from the workspace's node_modules and spawns them as local processes, which needs a real file system."
+      "supported": "limited",
+      "description": "Rslint, Rstest and `rs fmt` are resolved from the workspace's node_modules and spawned as local processes, so they only start for file-system workspace folders. In a virtual workspace only the status bar item is shown; no tool starts."
     },
     "untrustedWorkspaces": {
       "supported": "limited",


### PR DESCRIPTION
Preparation for publishing \`rstack.rstack@0.1.0\` to the VS Code Marketplace and Open VSX.

## Changes (package.json only)

- \`preview: true\` — the extension is pre-1.0 and breaks freely (per AGENTS.md); the Marketplace shows a **Preview** badge.
- \`qna\` → GitHub Issues, so questions land where they are actually read instead of the Marketplace Q&A tab.
- \`capabilities.virtualWorkspaces: { supported: false }\` — the extension resolves \`@rslint/core\`, \`@rstest/core\` and \`rstack\` from the workspace's \`node_modules\` and spawns them as local processes; VS Code's default (\`true\`) would let it activate in github.dev-style workspaces where it cannot work. \`untrustedWorkspaces\` was already declared.
- Add the missing top-level \`description\` for \`rstack.rstest.testCaseCollectMethod\` (the Settings UI showed only the per-value labels).

## Checked against the docs

- VS Code extension manifest reference: required fields (\`name\` lowercase, \`version\`, \`publisher\`, \`engines.vscode\`) and the presentation fields (\`displayName\`, \`description\`, \`categories\`, \`keywords\`, \`icon\` ≥128px, \`license\`, \`repository\`/\`bugs\`, \`preview\`, \`qna\`, \`capabilities\`) — all present now.
- Brand casing matches upstream READMEs / rstack.rs: \`Rstack\`, \`Rslint\`, \`Rstest\`, \`rs fmt\`.
- Open VSX: needs \`publisher\` = existing namespace (\`rstack\`, verified) and a license (MIT, \`LICENSE.txt\` is packaged) — satisfied.

Kept: version \`0.1.0\`, displayName \`Rstack\`.

## Verification

- \`pnpm lint && pnpm test:unit && pnpm fmt:check\` green.
- \`vsce package --target darwin-arm64\` succeeds; the VSIX manifest carries \`GalleryFlags: Public Preview\`, \`CustomerQnALink\`, and \`Links.Support\`.
- No E2E run: the change is declarative manifest metadata with no behavior in the local-file-system E2E environment.