### PR TITLE
feat(vscode): declare rstack.fmt.trace.server for the rs fmt language client

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -98,6 +98,7 @@ All settings live under the unified `rstack.*` namespace. There are no `rslint.*
 | `rstack.rstest.terminalShellPath` | — | Shell used by **Run in Terminal**. |
 | `rstack.rstest.terminalShellArgs` | `[]` | Shell args for **Run in Terminal**. |
 | `rstack.fmt.enable` | `true` | Enable/disable the formatter integration. |
+| `rstack.fmt.trace.server` | `off` | LSP trace level (`off` / `messages` / `verbose`); `messages` logs each formatting request's duration. |
 
 To use `rs fmt` as the formatter for supported documents, opt in through your VS Code settings: `"editor.defaultFormatter": "rstack.rstack"`. The extension never changes `editor.defaultFormatter` itself.
 

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -319,6 +319,18 @@
             "default": true,
             "scope": "window",
             "markdownDescription": "Enable the `rs fmt` document formatter for detected workspace folders. Requires `#rstack.enable#`. This is a window-level kill switch; which folders are formatted is decided by detection."
+          },
+          "rstack.fmt.trace.server": {
+            "order": 1,
+            "type": "string",
+            "enum": [
+              "off",
+              "messages",
+              "verbose"
+            ],
+            "default": "off",
+            "scope": "window",
+            "description": "Traces the communication between VS Code and the rs fmt language server (`messages` also shows how long each formatting request took)"
           }
         }
       }

--- a/packages/vscode/src/stacks/fmt/index.ts
+++ b/packages/vscode/src/stacks/fmt/index.ts
@@ -338,8 +338,12 @@ class FmtFolderRuntime {
     );
     this.#owner = owner;
     const serverOptions: ServerOptions = async () => owner.start();
+    // The id doubles as the configuration section vscode-languageclient reads
+    // `trace.server` from (and hot-reloads on change), so it must equal the
+    // declared `rstack.fmt.trace.server` prefix — the same pairing Biome
+    // (`biome.lsp`) and Oxc (`oxc`) rely on.
     const client = new FmtLanguageClient(
-      'rstack-fmt',
+      'rstack.fmt',
       `rs fmt Language Server (${this.folder.name})`,
       serverOptions,
       this.createClientOptions(),
@@ -481,6 +485,9 @@ class FmtFolderRuntime {
         // rslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         documentSelector as unknown as LanguageClientOptions['documentSelector'],
       outputChannel: this.context.output,
+      // Trace lines land in the stack's own channel next to its other logs
+      // instead of a separate "... Trace" channel per folder.
+      traceOutputChannel: this.context.output,
       errorHandler,
     };
   }


### PR DESCRIPTION
## Summary

Since fmt moved to `rs fmt --lsp` (#12) the old `Formatting completed in Xms` line is gone and there was no way to see how long a format request took: the language client's trace setting was neither declared nor namespaced (`rstack-fmt.trace.server` worked only as an undeclared key).

Align with how the other LSP-based formatter extensions expose this — a declared `<clientId>.trace.server` whose trace lands in the main output channel — rather than re-adding a custom timing log:

- Rename the fmt client id `rstack-fmt` → `rstack.fmt`, so vscode-languageclient reads `rstack.fmt.trace.server` and hot-reloads it on change (no restart involved).
- Set `traceOutputChannel` to the stack's own channel, so `Received response 'textDocument/formatting - (n)' in Xms` shows up in **Rstack: rs fmt** next to the other logs instead of a separate per-folder "Trace" channel.
- Declare `rstack.fmt.trace.server` (`off` / `messages` / `verbose`, default `off`, scope `window`) in `package.json`; document it in the README.

Verified: `pnpm lint`, `pnpm test:unit`, and `VSCODE_CLI=1 pnpm test:e2e vscode` all pass locally.

## Related Links

- #12

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
