### PR TITLE
build(vscode): minify release bundles and allowlist the VSIX contents

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
   "version": "2.0.0",
   "tasks": [
     {
-      // Background watch build the F5 launch depends on. SOURCEMAP=true
+      // Background watch build the F5 launch depends on. `--env-mode dev`
       // (`watch:local`) so breakpoints in src/ bind inside the dev host.
       "label": "extension watch",
       "type": "shell",

--- a/packages/vscode/.vscodeignore
+++ b/packages/vscode/.vscodeignore
@@ -1,5 +1,8 @@
+# Allowlist: only the built bundles and the staged native binding ship from
+# dist/ — never source maps.
 **
-!dist
+!dist/**/*.js
+!dist/**/*.node
 !icon.png
 !LICENSE
 !README.md

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -29,7 +29,7 @@
   "main": "./dist/extension.js",
   "scripts": {
     "build": "rslib build",
-    "build:local": "cross-env SOURCEMAP=true rslib build",
+    "build:local": "rslib build --env-mode dev",
     "package": "pnpm run build && vsce package",
     "package:targets": "node scripts/packageTargets.mjs",
     "test": "pnpm run test:unit && pnpm run test:e2e",
@@ -41,7 +41,7 @@
     "test:e2e:vscode": "node ./e2e/run.mjs vscode",
     "test:unit": "rstest",
     "watch": "rslib build --watch",
-    "watch:local": "cross-env SOURCEMAP=true rslib build --watch"
+    "watch:local": "rslib build --watch --env-mode dev"
   },
   "contributes": {
     "commands": [
@@ -452,7 +452,6 @@
     "@vscode/vsce": "^3.9.2",
     "birpc": "^4.0.0",
     "core-js-pure": "^3.49.0",
-    "cross-env": "^7.0.3",
     "mocha": "^11.7.6",
     "ovsx": "^1.0.2",
     "picomatch": "^4.0.5",

--- a/packages/vscode/rslib.config.mts
+++ b/packages/vscode/rslib.config.mts
@@ -39,8 +39,6 @@ const externals: NonNullable<NonNullable<LibConfig['output']>['externals']> = [
   },
 ];
 
-const sourceMap = process.env.SOURCEMAP === 'true';
-
 // The Rstest worker entry is owned by the Rstest stack and may not exist yet
 // while the stacks are still being copied in.
 const workerEntry = './src/stacks/test/worker/index.ts';
@@ -55,11 +53,6 @@ const libs: LibConfig[] = [
       entry: {
         extension: './src/extension.ts',
       },
-    },
-    output: {
-      target: 'node',
-      externals,
-      sourceMap,
     },
     tools: {
       rspack: {
@@ -99,11 +92,6 @@ if (hasWorkerEntry) {
         worker: workerEntry,
       },
     },
-    output: {
-      target: 'node',
-      externals,
-      sourceMap,
-    },
     tools: {
       rspack: {
         output: {
@@ -122,11 +110,6 @@ libs.push({
       'lint-worker': lintWorkerEntry,
     },
   },
-  output: {
-    target: 'node',
-    externals,
-    sourceMap,
-  },
   tools: {
     rspack: {
       output: {
@@ -136,4 +119,19 @@ libs.push({
   },
 });
 
-export default defineConfig({ lib: libs });
+/**
+ * Output shared by every bundle. `rslib build --env-mode dev` (`build:local`
+ * / `watch:local`) keeps readable output with source maps so breakpoints in
+ * `src/` bind in the dev host; the release build (`build`, used by CI and the
+ * Release workflow) minifies and emits no source maps.
+ */
+export default defineConfig(({ envMode }) => {
+  const devBuild = envMode === 'dev';
+  const output: LibConfig['output'] = {
+    target: 'node',
+    externals,
+    sourceMap: devBuild,
+    minify: !devBuild,
+  };
+  return { lib: libs.map((lib) => ({ ...lib, output })) };
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,6 @@ importers:
       core-js-pure:
         specifier: ^3.49.0
         version: 3.49.0
-      cross-env:
-        specifier: ^7.0.3
-        version: 7.0.3
       mocha:
         specifier: ^11.7.6
         version: 11.8.0
@@ -1234,11 +1231,6 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-
-  cross-env@7.0.3:
-    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
-    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
-    hasBin: true
 
   cross-keychain@1.1.0:
     resolution: {integrity: sha512-244DWNdGepLKD5vEn3reZqwzZFiE/LD4U+XV9IaXQbtIXKvQkf0VkRaOj/9vPYauPdR12PSGB3U0cE7jJi3WTQ==}
@@ -3523,10 +3515,6 @@ snapshots:
   core-js-pure@3.49.0: {}
 
   core-util-is@1.0.3: {}
-
-  cross-env@7.0.3:
-    dependencies:
-      cross-spawn: 7.0.6
 
   cross-keychain@1.1.0(@types/node@22.20.1):
     dependencies:


### PR DESCRIPTION
## Summary

- Two build modes, selected through rslib's `--env-mode`:
  - `build:local` / `watch:local` (`--env-mode dev`): readable output + source maps, so breakpoints in `src/` bind in the dev host (the F5 playground task already uses `watch:local`).
  - `build` (CI and the Release workflow): minified, no source maps. `extension.js` goes from 1.4 MB (rslib's lightly-compressed default) to 577 kB; the darwin-arm64 VSIX packs to ~546 KB.
- `.vscodeignore` is now an allowlist — `dist/**/*.js`, `dist/**/*.node`, icon, LICENSE, README, package.json — so source maps or anything else a local build leaves in `dist/` never reach the VSIX. Verified: after a `build:local`, `vsce ls` lists no `.map`.
- `cross-env` dropped; the mode travels as a CLI flag instead of an ad-hoc env var.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required). — `pnpm lint && pnpm test:unit` green; `smoke`, `rstest` and `vscode` E2E slices pass against the minified build.
- [x] Documentation updated (or not required).
