### PR TITLE
test(vscode): wait for expected diagnostics in fixAll E2E setups

### DIFF
--- a/packages/vscode/e2e/lint/fixtures/package.json
+++ b/packages/vscode/e2e/lint/fixtures/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Shared install root for the Rslint E2E fixture workspaces. The extension ships no binary: every fixture resolves @rslint/core - including its native Go binary, config-loader and eslint-plugin host - from this one published-npm install. jiti backs the config-file-loader's TypeScript-config fallback.",
   "dependencies": {
-    "@rslint/core": "^0.8.0",
+    "@rslint/core": "^0.8.1",
     "jiti": "^2.7.0"
   }
 }

--- a/packages/vscode/e2e/lint/suite/fixall-error.test.ts
+++ b/packages/vscode/e2e/lint/suite/fixall-error.test.ts
@@ -1,9 +1,10 @@
-// Ported verbatim from web-infra-dev/rslint
+// Ported from web-infra-dev/rslint (deviation: setup waits go through
+// waitForDiagnosticsWithMessages -- see fixall-helpers.ts for why).
 // `packages/vscode-extension/__tests__/suite/fixall-error.test.ts` (origin/main).
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import {
-  waitForDiagnostics,
+  waitForDiagnosticsWithMessages,
   waitForContentChange,
   findFixAllAction,
   requestFixAll,
@@ -57,7 +58,10 @@ suite('rslint fixAll - error flows', function () {
         editor,
         "const pVal: string = 'x';\nconst pRes = (pVal as string).trim();\n",
       );
-      const probeDiags = await waitForDiagnostics(doc);
+      const probeDiags = await waitForDiagnosticsWithMessages(
+        doc,
+        'no-unnecessary-type-assertion',
+      );
       assert.ok(
         probeDiags.some((d) =>
           d.message.includes('no-unnecessary-type-assertion'),

--- a/packages/vscode/e2e/lint/suite/fixall-helpers.ts
+++ b/packages/vscode/e2e/lint/suite/fixall-helpers.ts
@@ -19,6 +19,29 @@ import { waitForCodeActionRegistryQuiescence } from '../utils/codeActionRegistry
 export { saveDocumentOnce } from '../utils/codeActionRegistry';
 
 export const waitForDiagnostics = waitForRslintDiagnostics;
+
+/**
+ * Wait until the rslint diagnostics for `doc` include every given message
+ * substring.
+ *
+ * Deviation from the upstream suites, which assert on the first non-empty
+ * publish: since @rslint/core 0.8.1 (web-infra-dev/rslint#1790), a file
+ * created after its project was loaded is served by a type-info-less fallback
+ * Program until a watcher event admits it into the configured project, so the
+ * first non-empty publish may carry only non-type-aware rules on platforms
+ * with slow file watchers (macOS). Waiting for the expected diagnostics keeps
+ * the terminal assertion identical without depending on publish batching.
+ */
+export function waitForDiagnosticsWithMessages(
+  doc: vscode.TextDocument,
+  ...messages: string[]
+): Promise<vscode.Diagnostic[]> {
+  return waitForRslintDiagnostics(doc, (diagnostics) =>
+    messages.every((message) =>
+      diagnostics.some((diagnostic) => diagnostic.message.includes(message)),
+    ),
+  );
+}
 export const waitForDiagnosticsCount = waitForRslintDiagnosticsCount;
 export const waitForDiagnosticsToChange = waitForRslintDiagnosticsToChange;
 

--- a/packages/vscode/e2e/lint/suite/fixall-onsave.test.ts
+++ b/packages/vscode/e2e/lint/suite/fixall-onsave.test.ts
@@ -1,4 +1,5 @@
-// Ported verbatim from web-infra-dev/rslint
+// Ported from web-infra-dev/rslint (deviation: setup waits go through
+// waitForDiagnosticsWithMessages -- see fixall-helpers.ts for why).
 // `packages/vscode-extension/__tests__/suite/fixall-onsave.test.ts` (origin/main).
 import * as assert from 'assert';
 import * as vscode from 'vscode';
@@ -6,6 +7,7 @@ import { getRslintDiagnostics } from '../utils/diagnostics';
 import { waitForCodeActionRegistryQuiescence } from '../utils/codeActionRegistry';
 import {
   waitForDiagnostics,
+  waitForDiagnosticsWithMessages,
   waitForDiagnosticsCount,
   waitForContentChange,
   withOnSaveFixAll,
@@ -38,7 +40,10 @@ suite('rslint fixAll - on-save', function () {
           "const gfVal: string = 'x';\nconst gfRes = (gfVal as string).trim();\n",
         );
 
-        const diags = await waitForDiagnostics(doc);
+        const diags = await waitForDiagnosticsWithMessages(
+          doc,
+          'no-unnecessary-type-assertion',
+        );
         assertHasFixableDiagnostic(diags, 'generic source.fixAll setup');
 
         await saveDocumentOnce(
@@ -69,7 +74,10 @@ suite('rslint fixAll - on-save', function () {
       ].join('\n');
       await replaceAll(editor, fixableContent);
 
-      const diags = await waitForDiagnostics(doc);
+      const diags = await waitForDiagnosticsWithMessages(
+        doc,
+        'no-unnecessary-type-assertion',
+      );
       assertHasFixableDiagnostic(diags, 'fixable on-save setup');
 
       await saveDocumentOnce(doc, 'Fixable document should save');
@@ -93,7 +101,10 @@ suite('rslint fixAll - on-save', function () {
         editor,
         "const probeVal: string = 'x';\nconst probeRes = (probeVal as string).trim();\n",
       );
-      const probeDiags = await waitForDiagnostics(doc);
+      const probeDiags = await waitForDiagnosticsWithMessages(
+        doc,
+        'no-unnecessary-type-assertion',
+      );
       assertHasFixableDiagnostic(probeDiags, 'clean-file probe setup');
       await saveDocumentOnce(doc, 'Clean-file probe should save');
       await waitForContentChange(
@@ -130,7 +141,10 @@ suite('rslint fixAll - on-save', function () {
         editor,
         "const probeVal2: string = 'x';\nconst probeRes2 = (probeVal2 as string).trim();\n",
       );
-      const probeDiags = await waitForDiagnostics(doc);
+      const probeDiags = await waitForDiagnosticsWithMessages(
+        doc,
+        'no-unnecessary-type-assertion',
+      );
       assertHasFixableDiagnostic(probeDiags, 'non-fixable probe setup');
       await saveDocumentOnce(doc, 'Non-fixable probe should save');
       await waitForContentChange(

--- a/packages/vscode/e2e/lint/suite/fixall.test.ts
+++ b/packages/vscode/e2e/lint/suite/fixall.test.ts
@@ -1,9 +1,11 @@
-// Ported verbatim from web-infra-dev/rslint
+// Ported from web-infra-dev/rslint (deviation: setup waits go through
+// waitForDiagnosticsWithMessages -- see fixall-helpers.ts for why).
 // `packages/vscode-extension/__tests__/suite/fixall.test.ts` (origin/main).
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import {
   waitForDiagnostics,
+  waitForDiagnosticsWithMessages,
   waitForDiagnosticsToChange,
   waitForDiagnosticsCount,
   openFixture,
@@ -127,7 +129,10 @@ suite('rslint fixAll - code actions', function () {
     const fixableContent =
       "const frVal: string = 'hello';\nconst frRes = (frVal as string).toUpperCase();\n";
     await withTmpFile(fixableContent, async (doc) => {
-      const initialDiags = await waitForDiagnostics(doc);
+      const initialDiags = await waitForDiagnosticsWithMessages(
+        doc,
+        'no-unnecessary-type-assertion',
+      );
       assert.ok(initialDiags.length > 0, 'Should have initial diagnostics');
 
       const fixableDiags = initialDiags.filter((d) =>
@@ -166,7 +171,11 @@ suite('rslint fixAll - code actions', function () {
       '',
     ].join('\n');
     await withTmpFile(mixedContent, async (doc) => {
-      const initialDiags = await waitForDiagnostics(doc);
+      const initialDiags = await waitForDiagnosticsWithMessages(
+        doc,
+        'no-unnecessary-type-assertion',
+        'no-unsafe',
+      );
       assert.ok(initialDiags.length > 0, 'Should have diagnostics');
 
       const fixableBefore = initialDiags.filter((d) =>
@@ -248,7 +257,10 @@ suite('rslint fixAll - code actions', function () {
     const fixableContent =
       "const sfVal: string = 'x';\nconst sfRes = (sfVal as string).trim();\n";
     await withTmpFile(fixableContent, async (doc) => {
-      const initialDiags = await waitForDiagnostics(doc);
+      const initialDiags = await waitForDiagnosticsWithMessages(
+        doc,
+        'no-unnecessary-type-assertion',
+      );
       const fixableCount = initialDiags.filter((d) =>
         d.message.includes('no-unnecessary-type-assertion'),
       ).length;


### PR DESCRIPTION
## Summary

- macOS E2E started failing once the floating lint fixture picked up `@rslint/core` 0.8.1: since web-infra-dev/rslint#1790, a file created after its project was loaded is served by a type-info-less fallback Program until a watcher event admits it into the configured project. The first non-empty diagnostics publish can therefore carry only non-type-aware rules on platforms with slow file watchers (macOS) — and the fixAll suites, which create their targets via `withTmpFile`, asserted on exactly that first publish. Linux/Windows close the admission window before the first publish, which is why only macOS was red.
- Setup waits now go through a new `waitForDiagnosticsWithMessages` helper (documented deviation from the upstream suites) that waits until the expected diagnostics are present. The terminal assertions are unchanged and hold on both 0.8.0 and 0.8.1.
- The lint fixture floor moves to `^0.8.1` to match what CI resolves.

Verified locally on macOS against 0.8.1: all 10 lint E2E suites pass; `pnpm lint && pnpm test:unit` green.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
