### PR TITLE
test(vscode): widen multiroot E2E diagnostic deadline for slow runners

### DIFF
--- a/packages/vscode/e2e/lint/suite-multiroot/multiroot.test.ts
+++ b/packages/vscode/e2e/lint/suite-multiroot/multiroot.test.ts
@@ -1,5 +1,6 @@
-// Ported verbatim from web-infra-dev/rslint
-// `packages/vscode-extension/__tests__/suite-multiroot/multiroot.test.ts` (origin/main).
+// Ported from web-infra-dev/rslint
+// `packages/vscode-extension/__tests__/suite-multiroot/multiroot.test.ts` (origin/main),
+// with timing deviations documented inline (assertion semantics unchanged).
 import * as assert from 'node:assert';
 import path from 'node:path';
 import * as vscode from 'vscode';
@@ -31,7 +32,11 @@ function rslintDiagnostics(document: vscode.TextDocument): vscode.Diagnostic[] {
 async function waitForSingleRslintDiagnostic(
   document: vscode.TextDocument,
 ): Promise<vscode.Diagnostic[]> {
-  const deadline = Date.now() + 30_000;
+  // Deviation from upstream (30s): an ownership handoff spawns a fresh lint
+  // worker for the new owning folder, and that cold start has exceeded 30s on
+  // GitHub's windows runners (CI run 32718392387). The assertion semantics are
+  // unchanged — only the deadline is wider.
+  const deadline = Date.now() + 60_000;
   while (Date.now() < deadline) {
     const diagnostics = rslintDiagnostics(document);
     if (
@@ -63,7 +68,9 @@ async function waitForSingleRslintDiagnostic(
 }
 
 suite('VS Code multi-root ownership', function () {
-  this.timeout(60_000);
+  // Deviation from upstream (60s): the dynamic-ownership test below waits for
+  // up to three diagnostic publications, each with the widened 60s deadline.
+  this.timeout(240_000);
 
   test('keeps same-name roots independent', async function () {
     const appFolders = (vscode.workspace.workspaceFolders ?? []).filter(


### PR DESCRIPTION
## Why

CI run [32718392387](https://github.com/rstackjs/rstack-editor/actions/runs/32718392387) (attempt 1, `E2E (windows-latest)`) failed in the Multi-root dynamic ownership suite: `hands a document parent → child → parent without reopening it` asserted `0 !== 1` after `waitForSingleRslintDiagnostic`'s 30s deadline expired.

Diagnosis: an ownership handoff spawns a fresh lint worker for the new owning folder (resolve core → init → lint → publish). On GitHub's windows runners that cold start exceeded 30s once; the old owner had already cleared the document's diagnostics, so the wait returned 0. Same code passed windows E2E 6× on the PR branch and on rerun (attempt 2) — a timing flake, not a regression.

## What

- `waitForSingleRslintDiagnostic` deadline: 30s → 60s
- suite timeout: 60s → 240s (the dynamic-ownership test waits for up to three publications)

Assertion semantics are unchanged. Upstream (web-infra-dev/rslint `origin/main`) still uses 30s/60s; the deviations are documented inline per the ported-suite rule in `packages/vscode/AGENTS.md`.

## Verified

- `pnpm lint && pnpm test:unit` green
- `VSCODE_CLI=1 RSTACK_LINT_E2E_SUITES="Multi-root" pnpm test:e2e lint` — both Multi-root suites pass locally