### PR TITLE
docs: add supported versions matrix and roadmap to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Rstack Editor is where Rstack's editor support converges: it replaces the standa
 
 | Milestone | Status |
 | --- | --- |
-| Unified `rstack.rstack` extension on VS Code Marketplace and Open VSX | ✅ Shipped |
+| Unified [`rstack.rstack`](#install) extension on VS Code Marketplace and Open VSX | ✅ Shipped |
 | Core features: linting (Rslint), testing (Rstest), formatting (`rs fmt`) | ✅ Shipped |
 | Deprecation notices on the standalone extensions' marketplace listings | 🚧 Planned |
 | Sunset of the standalone extensions (final releases, listings pointing here) | 🚧 Planned |
@@ -52,7 +52,7 @@ Rstack Editor is where Rstack's editor support converges: it replaces the standa
 
 ### About the standalone extensions
 
-The standalone extensions are retired: all new editor features land in Rstack Editor. They remain published and keep working while the transition is underway, but we recommend switching now — install `rstack.rstack` and disable or uninstall the standalone extensions so only one copy of each tool runs.
+The standalone extensions are retired: all new editor features land in Rstack Editor. They remain published and keep working while the transition is underway, but we recommend switching now — install [`rstack.rstack`](#install) and disable or uninstall the standalone extensions so only one copy of each tool runs.
 
 Settings and keybindings are **not** migrated automatically: re-enter them under the `rstack.*` keys following the [migration notes](./packages/vscode/README.md#coming-from-the-standalone-extensions).
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,39 @@ Rstack Editor provides unified editor support for [Rstack](https://rstack.rs), t
 
 Or search for `rstack.rstack` in the editor's Extensions view.
 
+## Supported versions
+
+The extension resolves the tools from your project's `node_modules` and checks them against a support matrix at runtime:
+
+| Package        | Required  |
+| -------------- | --------- |
+| `@rslint/core` | `>=0.8.0` |
+| `@rstest/core` | `>=0.6.0` |
+| `rstack`       | `>=0.6.1` |
+
 ## Documentation
 
 - [VS Code extension](./packages/vscode/README.md) — installation, features, detection and settings
 - [Rstack](https://rstack.rs) · [Rslint](https://rslint.rs) · [Rstest](https://rstest.rs) — the tools the extension integrates
+
+## Roadmap
+
+Rstack Editor is where Rstack's editor support converges: it replaces the standalone [`rstack.rslint`](https://marketplace.visualstudio.com/items?itemName=rstack.rslint) and [`rstack.rstest`](https://marketplace.visualstudio.com/items?itemName=rstack.rstest) extensions with a single install. Where that migration stands:
+
+| Milestone | Status |
+| --- | --- |
+| Unified `rstack.rstack` extension on VS Code Marketplace and Open VSX | ✅ Shipped |
+| Core features: linting (Rslint), testing (Rstest), formatting (`rs fmt`) | ✅ Shipped |
+| Deprecation notices on the standalone extensions' marketplace listings | 🚧 Planned |
+| Sunset of the standalone extensions (final releases, listings pointing here) | 🚧 Planned |
+| 1.0: stable settings and command ids | 🚧 Planned |
+| Support for other editors (e.g. Zed) | 💡 Exploring |
+
+### About the standalone extensions
+
+The standalone extensions are retired: all new editor features land in Rstack Editor. They remain published and keep working while the transition is underway, but we recommend switching now — install `rstack.rstack` and disable or uninstall the standalone extensions so only one copy of each tool runs.
+
+Settings and keybindings are **not** migrated automatically: re-enter them under the `rstack.*` keys following the [migration notes](./packages/vscode/README.md#coming-from-the-standalone-extensions).
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Rstack Editor is where Rstack's editor support converges: it replaces the standa
 
 | Milestone | Status |
 | --- | --- |
-| Unified [`rstack.rstack`](#install) extension on VS Code Marketplace and Open VSX | ✅ Shipped |
+| Unified [Rstack](#install) extension on VS Code Marketplace and Open VSX | ✅ Shipped |
 | Core features: linting (Rslint), testing (Rstest), formatting (`rs fmt`) | ✅ Shipped |
 | Deprecation notices on the standalone extensions' marketplace listings | 🚧 Planned |
 | Sunset of the standalone extensions (final releases, listings pointing here) | 🚧 Planned |
@@ -52,7 +52,7 @@ Rstack Editor is where Rstack's editor support converges: it replaces the standa
 
 ### About the standalone extensions
 
-The standalone extensions are retired: all new editor features land in Rstack Editor. They remain published and keep working while the transition is underway, but we recommend switching now — install [`rstack.rstack`](#install) and disable or uninstall the standalone extensions so only one copy of each tool runs.
+The standalone extensions are retired: all new editor features land in Rstack Editor. They remain published and keep working while the transition is underway, but we recommend switching now — install the [Rstack](#install) extension and disable or uninstall the standalone extensions so only one copy of each tool runs.
 
 Settings and keybindings are **not** migrated automatically: re-enter them under the `rstack.*` keys following the [migration notes](./packages/vscode/README.md#coming-from-the-standalone-extensions).
 

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -42,8 +42,6 @@ The project-resolved packages are checked against a support matrix at runtime; a
 | `@rstest/core` | `>=0.6.0` |
 | `rstack`       | `>=0.6.1` |
 
-`rstack` 0.6.1 and `@rslint/core` 0.8.0 provide the explicit lint config protocol used by the Rstack bridge. Older releases report `version mismatch`.
-
 ## Auto-fix on save (Rslint)
 
 To automatically fix lint issues when saving, add this to your VS Code settings (`.vscode/settings.json`):
@@ -106,7 +104,7 @@ Formatting runs one `rs fmt` language server per workspace folder, which loads `
 
 ## Coming from the standalone extensions
 
-Settings and keybindings are not carried over from the retired `rstack.rslint` / `rstack.rstest` extensions: re-enter your settings under the `rstack.*` keys listed above and re-bind any keybinding to the new `rstack.*` command ids. Legacy `rslint.binPath` / `rslint.customBinPath` have no equivalent — use `rstack.rslint.corePath` to point at an `@rslint/core` package directory if you still need an override.
+Disable or uninstall the retired `rstack.rslint` / `rstack.rstest` extensions so only one copy of each tool runs. Settings and keybindings are not carried over from them: re-enter your settings under the `rstack.*` keys listed above and re-bind any keybinding to the new `rstack.*` command ids. Legacy `rslint.binPath` / `rslint.customBinPath` have no equivalent — use `rstack.rslint.corePath` to point at an `@rslint/core` package directory if you still need an override.
 
 ## Community
 


### PR DESCRIPTION
## Summary

Root README additions:

- **Supported versions** — the runtime support matrix (`@rslint/core >=0.8.0`, `@rstest/core >=0.6.0`, `rstack >=0.6.1`), matching `SUPPORT_MATRIX` and the extension README's table.
- **Roadmap** — where the migration off the standalone `rstack.rslint` / `rstack.rstest` extensions stands (shipped / planned / exploring), plus an **About the standalone extensions** section stating the deprecation stance: they stay published during the transition, switching now is recommended, and settings are not migrated automatically.

Extension README tweaks:

- Dropped the protocol-rationale sentence and the redundant `version mismatch` line from **Supported package versions** — the section now carries only the version table.
- **Coming from the standalone extensions** now also tells users to disable/uninstall the standalone extensions so only one copy of each tool runs.

## Related Links

- #15

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
