### PR TITLE
chore: let the rstack toolchain group own its release-age cooldown

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,9 +26,11 @@
     // The Rstack toolchain is what this repo exists to support and it ships
     // every few days, so it opts out of the weekly window entirely: a PR is
     // opened on the next run after a release. `schedule:weekly` still governs
-    // everything else, and `github>rstackjs/renovate:security` already waives
-    // the release-age cooldown for the same set. Listed after `all-patch` so
-    // these land in their own PR instead of the weekly patch roll-up.
+    // everything else. This group owns its cooldown policy end-to-end:
+    // `minimumReleaseAge: null` waives the security preset's 1-day cooldown
+    // for every package listed here, rather than relying on the preset's own
+    // waiver list staying in sync. Listed after `all-patch` so these land in
+    // their own PR instead of the weekly patch roll-up.
     //
     // This includes `@rslint/core`, `@rstest/core` and `rstack`, whose ranges
     // sit alongside the runtime `SUPPORT_MATRIX` (shared/versionCheck.ts).
@@ -50,6 +52,7 @@
         'rstack',
       ],
       schedule: ['at any time'],
+      minimumReleaseAge: null,
     },
   ],
 }


### PR DESCRIPTION
## Summary

The `rstack toolchain` Renovate group is meant to update as soon as a release ships (`schedule: ['at any time']`), but the shared security preset's cooldown waiver list does not cover `@rstackjs/**` and `rstack` — both in use here — so those updates were held back by the 1-day `minimumReleaseAge` while the rest of the group updated immediately. One toolchain release could thus split into two branch updates and two CI rounds.

Set `minimumReleaseAge: null` on the group so it owns its cooldown policy end-to-end, independent of the preset's waiver list, and reword the comment to state that intent (the old comment claimed the preset already waived the cooldown for the whole set, which was inaccurate).

Validated with `renovate-config-validator`; `pnpm lint` and `pnpm test:unit` pass.

## Related Links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).