### PR TITLE
chore: align VS Code configuration with Rstack

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,3 @@
 {
-  // Rslint powers `pnpm lint` in this repo; the extension surfaces the same
-  // diagnostics in the editor. To be replaced by `rstack.rstack` (this very
-  // extension) once it is published.
-  "recommendations": ["rstack.rslint"]
+  "recommendations": ["rstack.rstack"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,7 @@
     "**/tests-dist": true,
     "**/.vscode-test": true,
     "**/node_modules": true
-  }
+  },
+  "search.useIgnoreFiles": true,
+  "editor.defaultFormatter": "rstack.rstack"
 }


### PR DESCRIPTION
## Summary

VS Code does not use Rstack as the repository-wide default formatter. Align the shared editor settings with rsbuild-plugin-template. Recommend the Rstack extension alongside the formatter setting.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).